### PR TITLE
Drop test-level support for go 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19', '1.20', '1.21' ]
+        go: [ '1.20', '1.21' ]
     name: Test Go ${{ matrix.go }}
     steps:
       - uses: actions/setup-go@v5


### PR DESCRIPTION
Go 1.19 is out of general support now that 1.21 exists, and ginkgo no longer works with it. If we want to stay up-to-date (which we do), then we can't run our tests on go 1.19 anymore.

The library itself hasn't changed at all though.